### PR TITLE
Update charm scanner to improve accuracy with morphological transformation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,7 +7,7 @@
   import {isAppReady}       from 'stores/flags'
 
   const TITLE   = 'MHRise Charm Scanner'
-  const VERSION = '0.9.0'
+  const VERSION = '0.9.1'
 
   // let isDemoMode       = false
   let isNavigationOpen = true

--- a/src/util.js
+++ b/src/util.js
@@ -61,6 +61,9 @@ export function countImageDiffAtPoint(image, templateImage, trimRect, diffBinary
   const result = new cv.Mat()
   cv.threshold(diff, result, diffBinaryThreshold, 255, cv.THRESH_BINARY)
 
+  // 入力の濃淡で 1px の誤差が出ることがあるので補正
+  cv.morphologyEx(result, result, cv.MORPH_OPEN, cv.Mat.ones(2, 2, cv.CV_8U))
+
   const diffCount = cv.countNonZero(result)
 
   if (debug != null) {


### PR DESCRIPTION
キャプボ入力の際に、色味の違いで誤差が出ることがある。
閾値の調整では限界があるので、モルフォロジー変換して 1px の差は無視するようにしてみる。

精度が下がるケースがあれば revert する。